### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -15,7 +15,7 @@ jobs:
         id: release
       - name: Publish to Registry
         if: steps.release.outputs.is_latest == 'true'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-docker-tag.yml
+++ b/.github/workflows/publish-docker-tag.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore